### PR TITLE
Add interest level filtering to each kanban board column independently

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -26,6 +26,17 @@ const columnColors: Record<string, string> = {
   Withdrawn: "bg-gray-500",
 };
 
+type InterestFilter = "All" | "High" | "Medium" | "Low";
+
+const interestFilterOptions: InterestFilter[] = ["All", "High", "Medium", "Low"];
+
+const interestFilterColors: Record<InterestFilter, string> = {
+  All: "",
+  High: "text-red-500",
+  Medium: "text-amber-500",
+  Low: "text-muted-foreground",
+};
+
 function KanbanColumn({
   status,
   prospects,
@@ -35,35 +46,70 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
+  const columnSlug = status.replace(/\s+/g, "-").toLowerCase();
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${columnSlug}`}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
-        <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
+        <div className={`w-2 h-2 rounded-full shrink-0 ${columnColors[status] || "bg-gray-400"}`} />
         <h3 className="text-sm font-semibold truncate">{status}</h3>
         <Badge
           variant="secondary"
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          data-testid={`badge-count-${columnSlug}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
       </div>
-      <div className="flex-1 overflow-y-auto px-2 py-2">
+
+      <div className="flex items-center gap-1 px-2 pt-2 pb-1">
+        {interestFilterOptions.map((option) => (
+          <button
+            key={option}
+            onClick={() => setInterestFilter(option)}
+            data-testid={`filter-${columnSlug}-${option.toLowerCase()}`}
+            className={`flex-1 text-[10px] font-medium py-0.5 rounded transition-colors
+              ${
+                interestFilter === option
+                  ? "bg-secondary text-secondary-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+              }
+              ${interestFilter === option && option !== "All" ? interestFilterColors[option] : ""}
+            `}
+          >
+            {option}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-2 py-1">
         <div className="space-y-2">
           {isLoading ? (
             <>
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+          ) : filteredProspects.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center py-8 text-center"
+              data-testid={`empty-${columnSlug}`}
+            >
+              <p className="text-xs text-muted-foreground">
+                {prospects.length === 0 ? "No prospects" : "No matching prospects"}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
Implement client-side filtering for job postings within each kanban column based on interest level (All, High, Medium, Low) by adding state and UI elements to `client/src/pages/home.tsx`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e7fbf45a-a297-4736-8fb8-288b40235a02
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: efd7ac40-3788-4baa-845e-84c4950f337a
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1c75ab81-b34c-4ca0-a02d-41dc65da3038/e7fbf45a-a297-4736-8fb8-288b40235a02/KWErrSJ
Replit-Helium-Checkpoint-Created: true