### PR TITLE
Add salary range fields to prospect forms and display

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Loader2 } from "lucide-react";
+import { SalaryInput } from "@/components/salary-input";
 
 export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
   const { toast } = useToast();
@@ -37,6 +38,8 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       notes: "",
+      salaryMin: null,
+      salaryMax: null,
     },
   });
 
@@ -151,6 +154,46 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
                     ))}
                   </SelectContent>
                 </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="salaryMin"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Salary Min (optional)</FormLabel>
+                <FormControl>
+                  <SalaryInput
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="e.g. $80,000"
+                    data-testid="input-salary-min"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="salaryMax"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Salary Max (optional)</FormLabel>
+                <FormControl>
+                  <SalaryInput
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="e.g. $120,000"
+                    data-testid="input-salary-max"
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Loader2 } from "lucide-react";
+import { SalaryInput } from "@/components/salary-input";
 
 interface EditProspectFormProps {
   prospect: Prospect;
@@ -42,6 +43,8 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       notes: prospect.notes ?? "",
+      salaryMin: prospect.salaryMin ?? null,
+      salaryMax: prospect.salaryMax ?? null,
     },
   });
 
@@ -155,6 +158,46 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
                     ))}
                   </SelectContent>
                 </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="salaryMin"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Salary Min (optional)</FormLabel>
+                <FormControl>
+                  <SalaryInput
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="e.g. $80,000"
+                    data-testid="input-edit-salary-min"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="salaryMax"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Salary Max (optional)</FormLabel>
+                <FormControl>
+                  <SalaryInput
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder="e.g. $120,000"
+                    data-testid="input-edit-salary-max"
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { formatSalary } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
@@ -106,6 +107,17 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
         </div>
+
+        {(prospect.salaryMin != null || prospect.salaryMax != null) && (
+          <div className="flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400 font-medium" data-testid={`text-salary-${prospect.id}`}>
+            <DollarSign className="w-3 h-3 shrink-0" />
+            {prospect.salaryMin != null && prospect.salaryMax != null
+              ? `${formatSalary(prospect.salaryMin)} – ${formatSalary(prospect.salaryMax)}`
+              : prospect.salaryMin != null
+              ? `From ${formatSalary(prospect.salaryMin)}`
+              : `Up to ${formatSalary(prospect.salaryMax)}`}
+          </div>
+        )}
 
         {prospect.jobUrl && (
           <a

--- a/client/src/components/salary-input.tsx
+++ b/client/src/components/salary-input.tsx
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { Input } from "@/components/ui/input";
+import { parseSalary, formatSalary } from "@/lib/utils";
+
+interface SalaryInputProps {
+  value: number | null | undefined;
+  onChange: (value: number | null) => void;
+  placeholder?: string;
+  "data-testid"?: string;
+}
+
+export function SalaryInput({ value, onChange, placeholder, "data-testid": testId }: SalaryInputProps) {
+  const [display, setDisplay] = useState(formatSalary(value));
+
+  useEffect(() => {
+    setDisplay(formatSalary(value));
+  }, [value]);
+
+  return (
+    <Input
+      placeholder={placeholder}
+      value={display}
+      onChange={(e) => setDisplay(e.target.value)}
+      onBlur={() => {
+        const parsed = parseSalary(display);
+        onChange(parsed);
+        setDisplay(formatSalary(parsed));
+      }}
+      data-testid={testId}
+    />
+  );
+}

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,15 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function parseSalary(input: string): number | null {
+  const stripped = input.replace(/[$,\s]/g, "");
+  if (stripped === "") return null;
+  const num = parseInt(stripped, 10);
+  return isNaN(num) || num < 0 ? null : num;
+}
+
+export function formatSalary(value: number | null | undefined): string {
+  if (value == null) return "";
+  return "$" + value.toLocaleString("en-US");
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,8 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
+    if (body.salaryMin !== undefined) updates.salaryMin = body.salaryMin;
+    if (body.salaryMax !== undefined) updates.salaryMax = body.salaryMax;
 
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -22,6 +22,8 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   notes: text("notes"),
+  salaryMin: integer("salary_min"),
+  salaryMax: integer("salary_max"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -35,6 +37,8 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  salaryMin: z.number().int().min(0).optional().nullable(),
+  salaryMax: z.number().int().min(0).optional().nullable(),
 });
 
 export type InsertProspect = z.infer<typeof insertProspectSchema>;


### PR DESCRIPTION
Adds `salaryMin` and `salaryMax` integer columns to the `prospects` table, updates schema validation, and introduces a reusable `SalaryInput` component for formatted currency input in both add and edit prospect forms. The prospect card now displays the salary range if provided.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: e7fbf45a-a297-4736-8fb8-288b40235a02
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: b27ea648-8773-48bc-9692-1a7e85eb9f98
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/1c75ab81-b34c-4ca0-a02d-41dc65da3038/e7fbf45a-a297-4736-8fb8-288b40235a02/R5oyQMW
Replit-Helium-Checkpoint-Created: true